### PR TITLE
Renames for readability

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -152,6 +152,11 @@ class Frisby {
       _inspects: [],
       _expects: [],
       _failures: [],
+      _attempts: {
+        count: 0,
+        maxRetries: clone.retry || 0,
+        backoffMillis: clone.retryBackoff || clone.retry_backoff || 1000,
+      },
     })
 
     // Spec storage
@@ -161,8 +166,6 @@ class Frisby {
       itInfo: null,
       it: null,
       isNot: false,    // test negation
-      retry: clone.retry || 0,
-      retryBackoff: clone.retryBackoff || clone.retry_backoff || 1000,
 
       // For an app provided to a single test.
       app: null,
@@ -976,9 +979,9 @@ class Frisby {
    * @desc retry the request (good for flaky,slow tests)
    */
   retry (count, backoffMillis) {
-    this.current.retry = count
+    this._attempts.maxRetries = count
     if (typeof backoffMillis !== "undefined") {
-      this.current.retryBackoff = backoffMillis
+      this._attempts.backoffMillis = backoffMillis
     }
     return this
   }
@@ -1097,7 +1100,7 @@ class Frisby {
     // We add a little extra time so frisby can handle the timeout.
     const gracePeriodMillis = 25
     return this._timeout +
-      this.current.retry * (this.current.retryBackoff + this._timeout) +
+      this._attempts.maxRetries * (this._attempts.backoffMillis + this._timeout) +
       gracePeriodMillis
   }
 
@@ -1175,13 +1178,6 @@ class Frisby {
 
 
   _start (done) {
-    // Repeat request for this.current.retry times if request does not respond
-    // with this._timeout ms (except for POST requests).
-    this.current.tries = 0
-    this.current.retries = this.current.outgoing.method.toUpperCase() === 'POST'
-      ? 0
-      : this.current.retry
-
     // When an error occurs in a before() hook, stop executing before hooks and
     // move on to finally() hooks. This mimics Mocha's behavior of before() and
     // after() hooks. A dev-provided exception handler overrides this behavior.
@@ -1214,10 +1210,15 @@ class Frisby {
 
   _makeRequest (done) {
     let requestAlreadyTimedOut = false
-    this.current.tries++
+    this._attempts.count++
 
     const maybePerformRetry = () => {
-      if (this.current.tries > this.current.retries) {
+      // Do not retry POST requests.
+      if (this.current.outgoing.method.toUpperCase() === 'POST') {
+        return false
+      }
+
+      if (this._attempts.count > this._attempts.maxRetries) {
         return false
       }
 
@@ -1225,7 +1226,7 @@ class Frisby {
 
       setTimeout(() => {
         this._makeRequest(done)
-      }, this.current.retryBackoff)
+      }, this._attempts.backoffMillis)
 
       return true
     }
@@ -1238,8 +1239,8 @@ class Frisby {
       }
 
       let message = `Request timed out after ${this._timeout} ms`
-      if (this.current.tries > 1) {
-        message += ` (${this.current.tries} attempts)`
+      if (this._attempts.count > 1) {
+        message += ` (${this._attempts.count} attempts)`
       }
       this._noteExpectationFailed(new Error(message))
 

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -143,6 +143,16 @@ class Frisby {
     // Optional exception handler
     this._exceptionHandler = false
 
+    Object.assign(this, {
+      _hooks: {
+        before: [],
+        after: [],
+        finally: [],
+      },
+      _inspects: [],
+      _expects: [],
+    })
+
     // Spec storage
     this.current = {
       outgoing: {},
@@ -150,11 +160,6 @@ class Frisby {
       itInfo: null,
       it: null,
       isNot: false,    // test negation
-      inspections: [], // array of inspections to perform before the expectations
-      before: [],
-      expects: [],     // array expectations to perform
-      after: [],
-      finally: [],
       retry: clone.retry || 0,
       retryBackoff: clone.retryBackoff || clone.retry_backoff || 1000,
       failures: [],
@@ -591,16 +596,21 @@ class Frisby {
   }
 
 
+  _expect (fn) {
+    this._expects.push(fn)
+    return this
+  }
+
+
   /**
    * @param {number} ms - Maximum response timeout in n milliseconds
    * @return {object}
    * @desc HTTP max response time expect helper
    */
   expectMaxResponseTime (ms) {
-    this.current.expects.push(() => {
+    return this._expect(() => {
       chai.expect(this.current.response.time).to.be.lessThan(ms)
     })
-    return this
   }
 
 
@@ -610,10 +620,9 @@ class Frisby {
    * @desc HTTP status code expect helper
    */
   expectStatus (statusCode) {
-    this.current.expects.push(() => {
+    return this._expect(() => {
       chai.expect(this.current.response.status).to.equal(statusCode)
     })
-    return this
   }
 
 
@@ -631,7 +640,7 @@ class Frisby {
       allowMultipleHeaders: options.allowMultipleHeaders || false
     }
 
-    this.current.expects.push(function () {
+    return this._expect(function () {
       if(!options.allowMultipleHeaders && self.current.response.headers[header] instanceof Array){
         throw new Error("Header '" + header + "' present more than once in HTTP response. Pass {allowMultipleHeaders: true} in options if this is expected.")
       }
@@ -653,7 +662,6 @@ class Frisby {
         throw new Error("Header '" + header + "' not present in HTTP response")
       }
     })
-    return this
   }
 
   /**
@@ -663,19 +671,17 @@ class Frisby {
    * @desc HTTP header expect helper (using 'contains' instead of 'equals')
    */
   expectHeaderContains (header, content, options = {}) {
-    const self = this
-
     header = (header + "").toLowerCase()
     options = {
       allowMultipleHeaders: options.allowMultipleHeaders || false
     }
 
-    this.current.expects.push(function () {
-      if(!options.allowMultipleHeaders && self.current.response.headers[header] instanceof Array){
+    return this._expect(() => {
+      if(!options.allowMultipleHeaders && this.current.response.headers[header] instanceof Array){
         throw new Error("Header '" + header + "' present more than once in HTTP response. Pass {allowMultipleHeaders: true} in options if this is expected.")
       }
-      if (typeof self.current.response.headers[header] !== "undefined") {
-        const responseHeaders = [].concat(self.current.response.headers[header]).map(thisHeader => thisHeader.toLowerCase())
+      if (typeof this.current.response.headers[header] !== "undefined") {
+        const responseHeaders = [].concat(this.current.response.headers[header]).map(thisHeader => thisHeader.toLowerCase())
         chai.expect(responseHeaders).to
           .include.something.that.satisfies(thisHeader => thisHeader.toLowerCase().includes(content.toLowerCase()),
             content.toLowerCase() + ' not found in ' + responseHeaders)
@@ -688,7 +694,6 @@ class Frisby {
           "' not present in HTTP response")
       }
     })
-    return this
   }
 
   /**
@@ -710,11 +715,9 @@ class Frisby {
   expectNoHeader (header) {
     header = (header + "").toLowerCase()
 
-    this.current.expects.push(() => {
+    return this._expect(() => {
       chai.expect(this.current.response.headers).to.not.have.property(header)
     })
-
-    return this
   }
 
 
@@ -724,17 +727,15 @@ class Frisby {
    * @desc HTTP body expect helper
    */
   expectBodyContains (content) {
-    const self = this
-    this.current.expects.push(function () {
-      if (!_.isUndefined(self.current.response.body)) {
-        chai.expect(self.current.response.body).to.contain(content)
+    return this._expect(() => {
+      if (!_.isUndefined(this.current.response.body)) {
+        chai.expect(this.current.response.body).to.contain(content)
       } else {
-        throw new Error(
+        throw Error(
           "No HTTP response body was present or HTTP response was empty"
         )
       }
     })
-    return this
   }
 
 
@@ -744,20 +745,18 @@ class Frisby {
    * @desc Helper to check parse HTTP response body as JSON and check key types
    */
   expectJSONTypes (/* [tree], jsonTest */) {
-    const self = this
     const args = Array.from(arguments)
     const path = typeof args[0] === 'string' && args.shift()
     const jsonTest = typeof args[0] === 'object' && args.shift()
 
-    this.current.expects.push(function() {
+    return this._expect(() => {
       pm.matchJSONTypes({
-        jsonBody: _jsonParse(self.current.response.body),
+        jsonBody: _jsonParse(this.current.response.body),
         jsonTest: jsonTest,
-        isNot: self.current.isNot,
+        isNot: this.current.isNot,
         path: path
       })
     })
-    return this
   }
 
   /**
@@ -770,7 +769,7 @@ class Frisby {
     const path = typeof args[0] === 'string' && args.shift()
     jsonTest = typeof args[0] === 'object' && args.shift()
 
-    this.current.expects.push(() => {
+    return this._expect(() => {
       pm.matchJSON({
         jsonBody: _jsonParse(this.current.response.body),
         jsonTest,
@@ -778,7 +777,6 @@ class Frisby {
         path,
       })
     })
-    return this
   }
 
 
@@ -792,7 +790,7 @@ class Frisby {
     const path = typeof args[0] === 'string' && args.shift()
     jsonTest = typeof args[0] === 'object' && args.shift()
 
-    this.current.expects.push(() => {
+    return this._expect(() => {
       pm.matchContainsJSON({
         jsonBody: _jsonParse(this.current.response.body),
         jsonTest,
@@ -800,7 +798,6 @@ class Frisby {
         path,
       })
     })
-    return this
   }
 
 
@@ -829,7 +826,7 @@ class Frisby {
       }
     }
 
-    this.current.expects.push(() => {
+    return this._expect(() => {
       pm.matchJSONLength({
         jsonBody: _jsonParse(this.current.response.body),
         jsonTest: lengthSegments, // we aren't testing any JSON here, just use this to pass in the length segments
@@ -837,8 +834,6 @@ class Frisby {
         path,
       })
     })
-
-    return this
   }
 
 
@@ -848,6 +843,7 @@ class Frisby {
    * @desc inspection of data after request is made but before test is completed
    */
   inspect (cb) {
+    // This function uses both `self` and `this`. Are they different? Hmm.
     const self = this
 
     if (!cb) {
@@ -862,7 +858,7 @@ class Frisby {
       return util.inspect(self, { customInspect: false })
     }
 
-    this.current.inspections.push(function () {
+    this._inspects.push(function () {
       cb.call(this, self.current.response.error, self.currentRequestFinished
         .req, self.currentRequestFinished.res, self.current.response.body,
       self.current.response.headers)
@@ -1008,7 +1004,7 @@ class Frisby {
     if (!_.isFunction(cb)) {
       throw new Error('Expected Function object in before(), but got ' + typeof cb)
     }
-    this.current.before.push(cb)
+    this._hooks.before.push(cb)
     return this
   }
 
@@ -1023,12 +1019,12 @@ class Frisby {
       throw new Error('Expected Function object in after(), but got ' + typeof cb)
     }
     if (cb.length > 4) { // assume it has a callback function argument
-      this.current.after.push((done) => {
+      this._hooks.after.push((done) => {
         cb.call(this, this.current.response.error, this.currentRequestFinished.res,
           this.current.response.body, this.current.response.headers, done)
       })
     } else {
-      this.current.after.push(() => {
+      this._hooks.after.push(() => {
         cb.call(this, this.current.response.error, this.currentRequestFinished.res,
           this.current.response.body, this.current.response.headers)
       })
@@ -1051,10 +1047,9 @@ class Frisby {
    * })
    */
   afterJSON (cb) {
-    const self = this
-    this.current.after.push(function() {
-      const responseHeaders = _jsonParse(self.current.response.headers)
-      const bodyJSON = _jsonParse(self.current.response.body)
+    this._hooks.after.push(() => {
+      const responseHeaders = _jsonParse(this.current.response.headers)
+      const bodyJSON = _jsonParse(this.current.response.body)
       cb.call(this, bodyJSON, responseHeaders)
     })
     return this
@@ -1071,7 +1066,7 @@ class Frisby {
     if (!_.isFunction(cb)) {
       throw new Error('Expected Function object in finally(), but got ' + typeof cb)
     }
-    this.current.finally.push(cb)
+    this._hooks.finally.push(cb)
     return this
   }
 
@@ -1139,7 +1134,7 @@ class Frisby {
   }
 
 
-  _hooks (hooks, completionCallback) {
+  _runHooks (hooks, completionCallback) {
     let invokationIndex = 0
 
     // naiive implementation of async callback support:
@@ -1190,7 +1185,7 @@ class Frisby {
     // When an error occurs in a before() hook, stop executing before hooks and
     // move on to finally() hooks. This mimics Mocha's behavior of before() and
     // after() hooks. A dev-provided exception handler overrides this behavior.
-    this._hooks(this.current.before, (e) => {
+    this._runHooks(this._hooks.before, (e) => {
       if (e) {
         this.current.failures.push(e)
         this._finish(done)
@@ -1271,10 +1266,7 @@ class Frisby {
 
 
   _performInspections () {
-    for (let i = 0; i < this.current.inspections.length; i++) {
-      const fn = this.current.inspections[i]
-      fn.call(this)
-    }
+    this._inspects.forEach(fn => fn())
   }
 
 
@@ -1283,9 +1275,9 @@ class Frisby {
     // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
     // Some 'expects' helpers add more tests when executed (recursive
     // 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
-    for (let i = 0; i < this.current.expects.length; i++) {
+    for (let i = 0; i < this._expects.length; i++) {
       try {
-        this.current.expects[i].call(null)
+        this._expects[i].call(null)
       } catch (e) {
         const shouldStop = this._noteExpectationFailed(e)
         if (shouldStop) {
@@ -1322,7 +1314,7 @@ class Frisby {
     const invokeFinalHooks = () => {
       // Stop after the first error, mimicking Mocha's behavior in after()
       // callbacks.
-      this._hooks(this.current.finally, (e) => {
+      this._runHooks(this._hooks.finally, (e) => {
         if (e) {
           this.current.failures.push(e)
         }
@@ -1332,8 +1324,8 @@ class Frisby {
     }
 
     // Once a failure has occurred, stop running any remaining after() hooks.
-    if (didPass && this.current.after) {
-      this._hooks(this.current.after, (e) => {
+    if (didPass && this._hooks.after) {
+      this._runHooks(this._hooks.after, (e) => {
         if (e) {
           this.current.failures.push(e)
         }

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -151,6 +151,7 @@ class Frisby {
       },
       _inspects: [],
       _expects: [],
+      _failures: [],
     })
 
     // Spec storage
@@ -162,7 +163,6 @@ class Frisby {
       isNot: false,    // test negation
       retry: clone.retry || 0,
       retryBackoff: clone.retryBackoff || clone.retry_backoff || 1000,
-      failures: [],
 
       // For an app provided to a single test.
       app: null,
@@ -1187,7 +1187,7 @@ class Frisby {
     // after() hooks. A dev-provided exception handler overrides this behavior.
     this._runHooks(this._hooks.before, (e) => {
       if (e) {
-        this.current.failures.push(e)
+        this._failures.push(e)
         this._finish(done)
       } else {
         if (this.current.waits > 0) {
@@ -1203,7 +1203,7 @@ class Frisby {
   // Return `true` if should stop processing expectations.
   _noteExpectationFailed (e) {
     if (false === this._exceptionHandler) {
-      this.current.failures.push(e)
+      this._failures.push(e)
       return true
     } else {
       this._exceptionHandler.call(this, e)
@@ -1292,7 +1292,7 @@ class Frisby {
 
   // Execute further expects for the current spec (called from _invokeExpects)
   _finish (done) {
-    const didPass = this.current.failures.length === 0,
+    const didPass = this._failures.length === 0,
       didFail = !didPass
 
     if (didFail && this.current.outgoing.inspectOnFailure) {
@@ -1305,7 +1305,7 @@ class Frisby {
     const finalizeTest = () => {
       // Return null, sole error, or a MultiError.
       // https://github.com/joyent/node-verror#verrorerrorfromlisterrors
-      const retError = errorFromList(this.current.failures)
+      const retError = errorFromList(this._failures)
 
       // Finally call done to finish spec.
       done(retError)
@@ -1316,7 +1316,7 @@ class Frisby {
       // callbacks.
       this._runHooks(this._hooks.finally, (e) => {
         if (e) {
-          this.current.failures.push(e)
+          this._failures.push(e)
         }
 
         finalizeTest()
@@ -1327,7 +1327,7 @@ class Frisby {
     if (didPass && this._hooks.after) {
       this._runHooks(this._hooks.after, (e) => {
         if (e) {
-          this.current.failures.push(e)
+          this._failures.push(e)
         }
 
         invokeFinalHooks()

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -131,7 +131,7 @@ class Frisby {
    * @param {string} message - message to print for it()
    * @return {object}
    */
-  constructor (msg) {
+  constructor (message) {
     const clone = _.cloneDeep(Frisby.globalSetup())
 
     if (clone.request && clone.request.headers) {
@@ -144,6 +144,7 @@ class Frisby {
     this._exceptionHandler = false
 
     Object.assign(this, {
+      _message: message,
       _hooks: {
         before: [],
         after: [],
@@ -162,7 +163,6 @@ class Frisby {
     // Spec storage
     this.current = {
       outgoing: {},
-      describe: msg,
       itInfo: null,
       it: null,
       isNot: false,    // test negation
@@ -1109,11 +1109,12 @@ class Frisby {
    * Register the current Frisby test with Mocha.
    */
   toss () {
+    // Use `self` in order to preserve the Mocha context.
     const self = this
 
     const describeFn = this._only ? describe.only : describe
 
-    describeFn(self.current.describe, function () {
+    describeFn(self._message, function () {
       before(function () {
         if (self.current.useApp) {
           const { app, baseUri } = self.current.useApp

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1050,7 +1050,7 @@ class Frisby {
    * })
    */
   afterJSON (cb) {
-    this._hooks.after.push(() => {
+    this._hooks.after.push(function() {
       const responseHeaders = _jsonParse(this.current.response.headers)
       const bodyJSON = _jsonParse(this.current.response.body)
       cb.call(this, bodyJSON, responseHeaders)

--- a/test/frisby_global.js
+++ b/test/frisby_global.js
@@ -35,7 +35,7 @@ describe('Frisby object setup', function() {
     expect(f1.current.request).to.deep.equal(f2.current.request)
 
     // Different describe statements
-    expect(f1.current.describe).not.to.deep.equal(f2.current.describe)
+    expect(f1._message).not.to.deep.equal(f2._message)
 
     // Add header only to f1
     f1.addHeaders({

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -1834,11 +1834,11 @@ describe('Frisby matchers', function() {
     // effects which trigger a ("cb.call is not a function") error, which is
     // difficult to debug.
     const test = frisby.create(this.test.title)
-    expect(test.current.inspections).to.have.lengthOf(0)
+    expect(test._inspects).to.have.lengthOf(0)
     test.inspectJSON(() => {})
-    expect(test.current.inspections).to.have.lengthOf(1)
+    expect(test._inspects).to.have.lengthOf(1)
     util.inspect(test)
-    expect(test.current.inspections).to.have.lengthOf(1)
+    expect(test._inspects).to.have.lengthOf(1)
   })
 
   describe('exclusive tests', function () {


### PR DESCRIPTION
Just beginning some more code cleanup. I’d like to get rid of `self.current`, which tends to make the code harder to read and type. I started renaming keys to move them out.

This will be easier to review one commit at a time. When I merge it I'll rebase to keep that history.