### PR TITLE
Simplify _request, eliminating state in closure

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -23,7 +23,7 @@ const pkg = require('../package.json')
 const pm = require('./pathMatch')
 const qs = require('qs')
 const request = require('request')
-const stream = require('stream').Stream
+const Stream = require('stream').Stream
 const util = require('util')
 const { errorFromList } = require('verror')
 
@@ -502,10 +502,19 @@ class Frisby {
       } else if (!outgoing.body) {
         if (data instanceof Buffer) {
           outgoing.body = data
-        } else if (!(data instanceof stream)) {
+        } else if (!(data instanceof Stream)) {
           outgoing.body = qs.stringify(data)
         }
       }
+    }
+
+    if (params.form === true) {
+      outgoing.form = true
+      outgoing.formData = data
+    }
+
+    if (data instanceof Stream) {
+      outgoing.stream = data
     }
 
     //
@@ -527,65 +536,7 @@ class Frisby {
     //
     // Determine test runner function (request or provided mock)
     //
-    const runner = params.mock || request
-
-    //
-    // Add the topic for the specified request to the context of the current
-    // batch used by this suite.
-    //
-    this.current.it = cb => {
-      this.currentRequestFinished = false
-      const start = (new Date()).getTime()
-      const runCallback = (err, res, body) => {
-
-        if(err) {
-          body = "[IcedFrisby] Destination URL may be down or URL is invalid, " + err
-        }
-
-        const diff = (new Date()).getTime() - start
-
-        this.currentRequestFinished = {err: err, res: res, body: body, req: outgoing}
-
-        let headers = {}
-        if (res) {
-          headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
-        }
-        // Store relevant current response parts
-        this.current.response = {
-          error: err,
-          status: (res ? res.statusCode : 599), // use 599 - network connect timeout error
-          headers: headers,
-          body: body,
-          time: diff
-        }
-
-        return cb()
-      }
-
-      outgoing.timeout = this._timeout
-
-      let req = null
-
-      // Handle forms (normal data with {form: true} in params options)
-      if(!_.isUndefined(params.form) && params.form === true) {
-        delete outgoing.headers['content-type']
-        req = runner(outgoing, runCallback)
-        const form = req.form()
-        for(const field in data) {
-          form.append(field, data[field])
-        }
-      } else {
-        req = runner(outgoing, runCallback)
-      }
-
-      if ((data instanceof stream) && (
-        outgoing.method === 'POST' ||
-        outgoing.method === 'PUT' ||
-        outgoing.method === 'PATCH')) {
-        data.pipe(req)
-      }
-
-    }
+    outgoing.runner = params.mock || request
 
     return this
   }
@@ -1253,7 +1204,63 @@ class Frisby {
 
     const requestTimeoutId = setTimeout(handleRequestTimeout, this._timeout)
 
-    this.current.it(() => {
+    const start = cb => {
+      this.currentRequestFinished = false
+      const start = (new Date()).getTime()
+      const runCallback = (err, res, body) => {
+
+        if(err) {
+          body = "[IcedFrisby] Destination URL may be down or URL is invalid, " + err
+        }
+
+        const diff = (new Date()).getTime() - start
+
+        this.currentRequestFinished = {err: err, res: res, body: body, req: outgoing}
+
+        let headers = {}
+        if (res) {
+          headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
+        }
+        // Store relevant current response parts
+        this.current.response = {
+          error: err,
+          status: (res ? res.statusCode : 599), // use 599 - network connect timeout error
+          headers: headers,
+          body: body,
+          time: diff
+        }
+
+        return cb()
+      }
+
+      const { outgoing } = this.current
+
+      outgoing.timeout = this._timeout
+
+      let req = null
+
+      // Handle forms (normal data with {form: true} in params options)
+      if (outgoing.form === true) {
+        const data = outgoing.formData
+        delete outgoing.headers['content-type']
+        req = outgoing.runner(outgoing, runCallback)
+        const form = req.form()
+        for (const field in data) {
+          form.append(field, data[field])
+        }
+      } else {
+        req = outgoing.runner(outgoing, runCallback)
+      }
+
+      if (outgoing.stream && (
+        outgoing.method === 'POST' ||
+        outgoing.method === 'PUT' ||
+        outgoing.method === 'PATCH')) {
+        outgoing.stream.pipe(req)
+      }
+    }
+
+    start(() => {
       if (requestAlreadyTimedOut) {
         return
       }

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -148,7 +148,6 @@ class Frisby {
       outgoing: {},
       describe: msg,
       itInfo: null,
-      it: null,
       isNot: false,    // test negation
       inspections: [], // array of inspections to perform before the expectations
       before: [],


### PR DESCRIPTION
This isn't perfect, but it unravels one step of indirection in the request-making process by eliminating the `current.it` closure.