### PR TITLE
Remove greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ node_js:
   - 10
 
 before_install:
-  - npm install -g npm@6 greenkeeper-lockfile@1
-
-before_script:
-  - greenkeeper-lockfile-update
+  - npm install -g npm@6
 
 after_script:
-  # Only the first Node version listed will upload the lock file.
-  - greenkeeper-lockfile-upload
   - npm run coverage && coveralls < coverage/lcov.info && rm -rf coverage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://img.shields.io/travis/IcedFrisby/IcedFrisby.svg)](https://travis-ci.org/IcedFrisby/IcedFrisby/)
 [![Coverage Status](https://img.shields.io/coveralls/github/IcedFrisby/IcedFrisby.svg)](https://coveralls.io/github/IcedFrisby/IcedFrisby)
-[![Greenkeeper badge](https://badges.greenkeeper.io/IcedFrisby/IcedFrisby.svg)](https://greenkeeper.io/)
 [![npm](https://img.shields.io/npm/v/icedfrisby.svg)](http://www.npmjs.com/package/icedfrisby)
 [![npm@next](https://img.shields.io/npm/v/icedfrisby/next.svg)](https://github.com/IcedFrisby/IcedFrisby/releases)
 


### PR DESCRIPTION
I switched this project from Greenkeeper to Dependabot, which I've had much better experiences with. It actually works consistently with lockfiles, among other things.

This does some cleanup, removing the Greenkeeper badge and the scripts that run in CI.