### PR TITLE
Refactor _runHooks to enqueue its own failures

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1007,6 +1007,7 @@ class Frisby {
               nextHook.call(this, invokeNextHook)
             } catch (e) {
               if (false === this._exceptionHandler) {
+                this._failures.push(e)
                 //Fishbowler 25-6-2018: No unit tests for this line - currently unreachable.
                 return reject(e)
               } else {
@@ -1020,6 +1021,7 @@ class Frisby {
               nextHook.call(this)
             } catch (e) {
               if (false === this._exceptionHandler) {
+                this._failures.push(e)
                 return reject(e)
               } else {
                 this._exceptionHandler(e)
@@ -1048,8 +1050,7 @@ class Frisby {
           this._makeRequest(done)
         }
       })
-      .catch(e => {
-        this._failures.push(e)
+      .catch(() => {
         this._finish(done)
       })
   }
@@ -1319,8 +1320,7 @@ class Frisby {
         .then(() => {
           finalizeTest()
         })
-        .catch(e => {
-          this._failures.push(e)
+        .catch(() => {
           finalizeTest()
         })
     }
@@ -1331,8 +1331,7 @@ class Frisby {
         .then(() => {
           invokeFinalHooks()
         })
-        .catch(e => {
-          this._failures.push(e)
+        .catch(() => {
           invokeFinalHooks()
         })
     } else {


### PR DESCRIPTION
This makes it a bit easier to ensure it's being used correctly.