### PR TITLE
Refactor _makeRequest

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1248,7 +1248,7 @@ class Frisby {
       this._invokeExpects(done)
     })
 
-    // A couple things that have to happen after the request fires.
+    // Deal with a couple things that have to happen after the request fires.
     if (params.form === true) {
       const form = req.form()
       for (const field in outgoing.formData) {

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1120,49 +1120,6 @@ class Frisby {
     this._attempts.count++
     this._requestDidTimeOut = false
     this.currentRequestFinished = false
-    const start = new Date().getTime()
-
-    const onRequestDone = (err, res, body) => {
-      if (err) {
-        body =
-          '[IcedFrisby] Destination URL may be down or URL is invalid, ' + err
-      }
-
-      const diff = new Date().getTime() - start
-
-      this.currentRequestFinished = {
-        err: err,
-        res: res,
-        body: body,
-        req: outgoing,
-      }
-
-      let headers = {}
-      if (res) {
-        headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
-      }
-      // Store relevant current response parts
-      this._response = {
-        error: err,
-        status: res ? res.statusCode : 599, // use 599 - network connect timeout error
-        headers: headers,
-        body: body ? body : '', //request already guarantees a body - this guarantees that developer mock functions are consistent
-        time: diff,
-      }
-
-      if (this._requestDidTimeOut) {
-        return
-      }
-
-      this._cancelTimeout()
-
-      if (this._response.status >= 500 && this._maybePerformRetry(done)) {
-        return
-      }
-
-      this._performInspections()
-      this._invokeExpects(done)
-    }
 
     const { method, uri, params } = this._requestArgs
     let { data } = this._requestArgs
@@ -1246,10 +1203,52 @@ class Frisby {
       delete outgoing.headers['content-type']
     }
 
+    const requestStartTime = new Date().getTime()
     this._scheduleTimeout(done)
 
-    const req = this._runner(outgoing, onRequestDone)
+    const req = this._runner(outgoing, (err, res, body) => {
+      if (err) {
+        body =
+          '[IcedFrisby] Destination URL may be down or URL is invalid, ' + err
+      }
 
+      const requestDuration = new Date().getTime() - requestStartTime
+
+      this.currentRequestFinished = {
+        err: err,
+        res: res,
+        body: body,
+        req: outgoing,
+      }
+
+      let headers = {}
+      if (res) {
+        headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
+      }
+      // Store relevant current response parts
+      this._response = {
+        error: err,
+        status: res ? res.statusCode : 599, // use 599 - network connect timeout error
+        headers: headers,
+        body: body ? body : '', //request already guarantees a body - this guarantees that developer mock functions are consistent
+        time: requestDuration,
+      }
+
+      if (this._requestDidTimeOut) {
+        return
+      }
+
+      this._cancelTimeout()
+
+      if (this._response.status >= 500 && this._maybePerformRetry(done)) {
+        return
+      }
+
+      this._performInspections()
+      this._invokeExpects(done)
+    })
+
+    // A couple things that have to happen after the request fires.
     if (params.form === true) {
       const form = req.form()
       for (const field in outgoing.formData) {

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -130,7 +130,7 @@ class Frisby {
       },
       _inspectOnFailure: true,
       _requestTimeoutId: undefined,
-      _requestHasTimedOut: false,
+      _requestDidTimeOut: false,
     })
 
     // Spec storage
@@ -1080,7 +1080,7 @@ class Frisby {
     const { _timeout: timeoutMillis } = this
 
     this._requestTimeoutId = setTimeout(() => {
-      this._requestHasTimedOut = true
+      this._requestDidTimeOut = true
 
       if (this._maybePerformRetry(done)) {
         return
@@ -1117,160 +1117,40 @@ class Frisby {
   }
 
   _makeRequest(done) {
-    this._requestHasTimedOut = false
     this._attempts.count++
+    this._requestDidTimeOut = false
+    this.currentRequestFinished = false
+    const start = new Date().getTime()
 
-    const start = cb => {
-      this.currentRequestFinished = false
-      const start = new Date().getTime()
-      const runCallback = (err, res, body) => {
-        if (err) {
-          body =
-            '[IcedFrisby] Destination URL may be down or URL is invalid, ' + err
-        }
-
-        const diff = new Date().getTime() - start
-
-        this.currentRequestFinished = {
-          err: err,
-          res: res,
-          body: body,
-          req: outgoing,
-        }
-
-        let headers = {}
-        if (res) {
-          headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
-        }
-        // Store relevant current response parts
-        this._response = {
-          error: err,
-          status: res ? res.statusCode : 599, // use 599 - network connect timeout error
-          headers: headers,
-          body: body ? body : '', //request already guarantees a body - this guarantees that developer mock functions are consistent
-          time: diff,
-        }
-
-        return cb()
+    const onRequestDone = (err, res, body) => {
+      if (err) {
+        body =
+          '[IcedFrisby] Destination URL may be down or URL is invalid, ' + err
       }
 
-      const { method, uri, params } = this._requestArgs
-      let { data } = this._requestArgs
+      const diff = new Date().getTime() - start
 
-      // Merge 'current' request options for current request
-      const outgoing = Object.assign(
-        {
-          json: params.json || (this.current.request.json || false),
-          uri: (this.current.request.baseUri || '') + uri,
-          body: params.body || undefined,
-          method,
-          headers: {},
-          timeout: this._timeout,
-        },
-        this.current.request,
-        params
-      )
-
-      outgoing.headers = Object.assign(
-        {},
-        this.current.request.headers,
-        params.headers
-      )
-
-      // Store outgoing request on current Frisby object for inspection in
-      // unit tests.
-      this._outgoing = outgoing
-
-      // Explicit setting of 'body' param overrides data
-      if (params.body) {
-        data = params.body
+      this.currentRequestFinished = {
+        err: err,
+        res: res,
+        body: body,
+        req: outgoing,
       }
 
-      // Normalize content-type
-      const contentTypeKey = _hasHeader('content-type', outgoing.headers)
-      if (contentTypeKey !== 'content-type') {
-        outgoing.headers['content-type'] = outgoing.headers[contentTypeKey]
-        delete outgoing.headers[contentTypeKey]
+      let headers = {}
+      if (res) {
+        headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
+      }
+      // Store relevant current response parts
+      this._response = {
+        error: err,
+        status: res ? res.statusCode : 599, // use 599 - network connect timeout error
+        headers: headers,
+        body: body ? body : '', //request already guarantees a body - this guarantees that developer mock functions are consistent
+        time: diff,
       }
 
-      // Ensure we have at least one 'content-type' header
-      if (_.isUndefined(outgoing.headers['content-type'])) {
-        outgoing.headers['content-type'] = 'application/x-www-form-urlencoded'
-      }
-
-      // If the content-type header contains 'json' but outgoing.json is false, the user likely messed up. Warn them.
-      if (
-        !outgoing.json &&
-        data &&
-        outgoing.headers['content-type'].indexOf('json') > -1
-      ) {
-        console.warn(
-          chalk.yellow.bold(
-            'WARNING - content-type is json but body type is not set'
-          )
-        )
-      }
-
-      // If the user has provided data, assume that it is query string and set
-      // it to the `body` property of the options.
-      if (data) {
-        if (outgoing.json) {
-          const isContentTypeHeaderMissing =
-            outgoing.headers['content-type'] &&
-            outgoing.headers['content-type'].indexOf('application/json') === -1
-
-          if (isContentTypeHeaderMissing) {
-            outgoing.headers['content-type'] = 'application/json'
-          }
-
-          outgoing.body = data
-        } else if (!outgoing.body) {
-          if (data instanceof Buffer) {
-            outgoing.body = data
-          } else if (!(data instanceof Stream)) {
-            outgoing.body = qs.stringify(data)
-          }
-        }
-      }
-
-      if (params.form === true) {
-        outgoing.form = true
-        outgoing.formData = data
-      }
-
-      if (data instanceof Stream) {
-        outgoing.stream = data
-      }
-
-      let req = null
-
-      // Handle forms (normal data with {form: true} in params options)
-      if (outgoing.form === true) {
-        const data = outgoing.formData
-        delete outgoing.headers['content-type']
-        req = this._runner(outgoing, runCallback)
-        const form = req.form()
-        for (const field in data) {
-          form.append(field, data[field])
-        }
-      } else {
-        req = this._runner(outgoing, runCallback)
-      }
-
-      if (
-        outgoing.stream &&
-        (outgoing.method === 'POST' ||
-          outgoing.method === 'PUT' ||
-          outgoing.method === 'PATCH')
-      ) {
-        outgoing.stream.pipe(req)
-      }
-    }
-
-    this._scheduleTimeout(done)
-
-    start(() => {
-      if (this._requestHasTimedOut) {
+      if (this._requestDidTimeOut) {
         return
       }
 
@@ -1282,7 +1162,104 @@ class Frisby {
 
       this._performInspections()
       this._invokeExpects(done)
-    })
+    }
+
+    const { method, uri, params } = this._requestArgs
+    let { data } = this._requestArgs
+
+    const outgoing = {
+      json: params.json || (this.current.request.json || false),
+      uri: (this.current.request.baseUri || '') + uri,
+      body: params.body || undefined,
+      method,
+      timeout: this._timeout,
+      ...this.current.request,
+      ...params,
+      ...{
+        headers: {
+          ...this.current.request.headers,
+          ...params.headers,
+        },
+      },
+      form: params.form,
+      formData: params.form ? data : undefined,
+      stream: data instanceof Stream ? data : undefined,
+    }
+
+    // Store outgoing request on current Frisby object for inspection in unit
+    // tests.
+    this._outgoing = outgoing
+
+    // Explicit setting of 'body' param overrides data.
+    if (params.body) {
+      data = params.body
+    }
+
+    // Normalize case of Content-Type header to simplify the header
+    // manipulation that follows.
+    const contentTypeKey = _hasHeader('content-type', outgoing.headers)
+    if (contentTypeKey !== 'content-type') {
+      outgoing.headers['content-type'] = outgoing.headers[contentTypeKey]
+      delete outgoing.headers[contentTypeKey]
+    }
+
+    // Ensure we have at least one 'content-type' header
+    if (outgoing.headers['content-type'] === undefined) {
+      outgoing.headers['content-type'] = 'application/x-www-form-urlencoded'
+    }
+
+    // If the content-type header contains 'json' but outgoing.json is false,
+    // the user likely messed up. Warn them.
+    if (
+      !outgoing.json &&
+      data &&
+      outgoing.headers['content-type'].includes('json')
+    ) {
+      console.warn(
+        chalk.yellow.bold(
+          'WARNING - content-type is json but body type is not set'
+        )
+      )
+    }
+
+    // If the user has provided data, assume that it is query string and set
+    // it to the `body` property of the options.
+    if (data) {
+      if (outgoing.json) {
+        outgoing.body = data
+        if (
+          outgoing.headers['content-type'] &&
+          !outgoing.headers['content-type'].includes('application/json')
+        ) {
+          outgoing.headers['content-type'] = 'application/json'
+        }
+      } else if (!outgoing.body) {
+        if (data instanceof Buffer) {
+          outgoing.body = data
+        } else if (!(data instanceof Stream)) {
+          outgoing.body = qs.stringify(data)
+        }
+      }
+    }
+
+    if (params.form === true) {
+      delete outgoing.headers['content-type']
+    }
+
+    this._scheduleTimeout(done)
+
+    const req = this._runner(outgoing, onRequestDone)
+
+    if (params.form === true) {
+      const form = req.form()
+      for (const field in outgoing.formData) {
+        form.append(field, data[field])
+      }
+    }
+
+    if (outgoing.stream && ['POST', 'PUT', 'PATCH'].includes(outgoing.method)) {
+      outgoing.stream.pipe(req)
+    }
   }
 
   _performInspections() {


### PR DESCRIPTION
This removes a layer of indirection within `_makeRequest`. This reads much more directly than it did before, though it's a gnarly diff, and the method is still pretty long.