### PR TITLE
Correctly emit exceptions from after() and finally()

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1223,7 +1223,7 @@ class Frisby {
       break
     }
 
-    const didFail = this._failures.length > 0
+    let didFail = this._failures.length > 0
 
     if (didFail && this._inspectOnFailure) {
       console.log(`${this.testInfo} has FAILED with the following response:`)
@@ -1237,7 +1237,7 @@ class Frisby {
       try {
         await this._runHooks(this._hooks.after)
       } catch (e) {
-        // Nothing to do.
+        didFail = true
       }
     }
 
@@ -1245,7 +1245,7 @@ class Frisby {
     try {
       await this._runHooks(this._hooks.finally)
     } catch (e) {
-      // Nothing to do.
+      didFail = true
     }
 
     if (didFail) {

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -778,6 +778,25 @@ describe('Frisby matchers', function() {
 
     it('TODO: should not be invoked after a test failure')
 
+    it('when a hook raised an exception, it should forward it', async function() {
+      const scope = nock('http://example.test')
+        .get('/')
+        .reply(200, fixtures.singleObject)
+
+      await expect(
+        frisby
+          .create(this.test.title)
+          .get('http://example.test/')
+          .expectStatus(200)
+          .after(() => {
+            throw Error('Error in after()')
+          })
+          .run()
+      ).to.be.rejectedWith(Error, 'Error in after()')
+
+      scope.done()
+    })
+
     // TODO: This is failing; not sure if it's due to the rewrite, or a previous
     // change, or if it was broken before, too.
     it.skip('should not be invoked after a previous after hook raised an exception', async function() {
@@ -958,6 +977,25 @@ describe('Frisby matchers', function() {
       ).to.be.rejectedWith(AssertionError, 'expected 200 to equal 204')
 
       expect(finallyInvoked.calledOnce).to.be.true
+      scope.done()
+    })
+
+    it('when a hook raised an exception, it should forward it', async function() {
+      const scope = nock('http://example.test')
+        .get('/')
+        .reply(200, fixtures.singleObject)
+
+      await expect(
+        frisby
+          .create(this.test.title)
+          .get('http://example.test/')
+          .expectStatus(200)
+          .finally(() => {
+            throw Error('Error in finally()')
+          })
+          .run()
+      ).to.be.rejectedWith(Error, 'Error in finally()')
+
       scope.done()
     })
 


### PR DESCRIPTION
Fix #206