### PR TITLE
update for Joi 16

### DIFF
--- a/lib/pathMatch.js
+++ b/lib/pathMatch.js
@@ -278,6 +278,7 @@ pathMatch.matchJSONTypes = function(check) {
       'Joi is required to use expectJSONTypes, and must be installed separately (npm i @hapi/joi)'
     )
   }
+  const schema = Joi.compile(check.jsonTest)
 
   // setup the data (validate check object, apply defaults)
   check = setup(check)
@@ -307,16 +308,16 @@ pathMatch.matchJSONTypes = function(check) {
 
     check.jsonBody.forEach(json => {
       // expect(json).toContainJsonTypes(jsonTest, self.current.isNot)
-      Joi.validate(json, check.jsonTest, function(err, value) {
-        if (err) {
-          if (check.isNot) {
-            // there is an error but isNot case is true. Increment counter.
-            errorCount++
-          } else {
-            throw err
-          }
+      try {
+        Joi.assert(json, schema)
+      } catch (err) {
+        if (check.isNot) {
+          // there is an error but isNot case is true. Increment counter.
+          errorCount++
+        } else {
+          throw err
         }
-      })
+      }
     })
 
     // if this is the isNot case, ALL the validations should have failed for the '*' case
@@ -351,16 +352,13 @@ pathMatch.matchJSONTypes = function(check) {
       throw new Error('There are no JSON objects to match against')
     }
 
-    // callback function for a Joi validation
-    const joiCb = function(err, value) {
-      if (err) {
+    for (let i = 0; i < itemCount; i++) {
+      try {
+        Joi.assert(check.jsonBody[i], schema)
+      } catch (err) {
         // didn't match this object, increment number of errors
         errorCount++
       }
-    }
-
-    for (let i = 0; i < itemCount; i++) {
-      Joi.validate(check.jsonBody[i], check.jsonTest, joiCb)
     }
 
     // If all errors, test fails
@@ -369,11 +367,13 @@ pathMatch.matchJSONTypes = function(check) {
     }
     // Normal matcher, entire object/array should match
   } else {
-    Joi.validate(check.jsonBody, check.jsonTest, function(err, value) {
-      if (err && !check.isNot) {
+    try {
+      Joi.assert(check.jsonBody, schema)
+    } catch (err) {
+      if (!check.isNot) {
         throw err
       }
-    })
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,45 +129,47 @@
       }
     },
     "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
-      "dev": true,
-      "optional": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
+      "integrity": "sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==",
+      "dev": true
     },
-    "@hapi/bourne": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
-      "dev": true,
-      "optional": true
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
+      "dev": true
     },
     "@hapi/hoek": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
-      "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==",
-      "dev": true,
-      "optional": true
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+      "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==",
+      "dev": true
     },
     "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.1.tgz",
+      "integrity": "sha512-5TdjUnNAaK7+lWZ2HRXtgOnxe4VBoJLoX0XOrfkmw+2n4/VJ6wwOJMoD7u/F9alLsP31kOWDbnQhtS0WAKwD4Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
+        "@hapi/formula": "1.x.x",
         "@hapi/hoek": "8.x.x",
+        "@hapi/pinpoint": "1.x.x",
         "@hapi/topo": "3.x.x"
       }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
+      "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
       "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@hapi/hoek": "8.x.x"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-mocha": "^6.0.0",
     "express": "^4.14.0",
     "intercept-stdout": "^0.1.2",
-    "@hapi/joi": "^15.0.3",
+    "@hapi/joi": "^16.0.1",
     "mocha": "^6.0.0",
     "mocha-lcov-reporter": "^1.2.0",
     "nock": "11.3.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha": "*"
   },
   "optionalDependencies": {
-    "@hapi/joi": "*"
+    "@hapi/joi": ">=16.0.0"
   },
   "devDependencies": {
     "chai-as-promised": "^7.1.1",

--- a/test/pathMatch.js
+++ b/test/pathMatch.js
@@ -601,9 +601,7 @@ describe('Path match JSON Types', function() {
       })
     }
 
-    expect(fn).to.throw(
-      'child "nonexistentField" fails because ["nonexistentField" is required]'
-    )
+    expect(fn).to.throw('"nonexistentField" is required')
   })
 
   it('should allow a simple object with isNot set', function() {
@@ -673,7 +671,7 @@ describe('Path match JSON Types', function() {
       })
     }
 
-    expect(fn).to.throw('"num" fails because ["num" must be one of [999]]')
+    expect(fn).to.throw('"num" must be [999]')
   })
 
   it("should allow one object in an array with an 'array.?' path", function() {
@@ -725,7 +723,7 @@ describe('Path match JSON Types', function() {
       })
     }
 
-    expect(fn).to.throw('"num" fails because ["num" must be one of [999]]')
+    expect(fn).to.throw('"num" must be [999]')
   })
 
   it("should allow any object in an array with an 'array.*' path when isNot is set", function() {


### PR DESCRIPTION
Refs #304

Joi 16 moves `validate()` to a method on `schema` and removes the the ability to pass a callback to `validate()` I've switched to using `Joi.assert()` with `try`/`catch` here to minimise disruption.