### PR TITLE
fix tests - httpbin tests, add X-Amzn-Trace-Id

### DIFF
--- a/test/frisby_httpbin.js
+++ b/test/frisby_httpbin.js
@@ -103,6 +103,7 @@ describe('Frisby live running httpbin tests', function() {
               .required()
               .valid('1024'),
             Host: Joi.any(),
+            'X-Amzn-Trace-Id': Joi.any(),
           }),
         args: Joi.any(),
         files: Joi.any(),
@@ -185,6 +186,7 @@ describe('Frisby live running httpbin tests', function() {
               .required()
               .valid('' + patchCommand.length),
             Host: Joi.any(),
+            'X-Amzn-Trace-Id': Joi.any(),
           }),
         args: Joi.any(),
         files: Joi.any(),
@@ -225,6 +227,7 @@ describe('Frisby live running httpbin tests', function() {
               .required()
               .valid('' + patchCommand.length),
             Host: Joi.any(),
+            'X-Amzn-Trace-Id': Joi.any(),
           }),
         args: Joi.any(),
         files: Joi.any(),


### PR DESCRIPTION
Looks like httpbin returns this header on the following tests:

"X-Amzn-Trace-Id" [1]: "Root=1-5e861b22-67f840ac7b8b8767ac177733"

- sending binary data via put or post requests using Buffer objects should work
- sending binary data via put or post requests using Stream objects should work
- PATCH requests with Buffer and Stream objects should work

This is just a quick fix to deal with the response we're seeing from httpbin and to get tests passing again.